### PR TITLE
Refactor operator's code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ just a bump of classes that represent the quantum circuit and a toy example.
 
 The main reason is learn and apply concepts of quantum computing and c++ OOP
 
-## How to use the code
-The *g++ -std=c++14 -Wall files.cpp -o aux.out*
+## Execute the code
+To execute your circuit, you must edit the makefile to use your file.
+
+After that, you just use *make* and the compiled file will be created.
 

--- a/qc-circuit/operators.cpp
+++ b/qc-circuit/operators.cpp
@@ -16,26 +16,7 @@ OneQubit::OneQubit( const int indice ){
 
 OneQubit::~OneQubit(){ std::cout<<"Destructor OneQubit"<<std::endl; };
 
-TwoQubit::TwoQubit( const int indice1, const int indice2 ){
-  (this->indice_1) = indice1;
-  (this->indice_2) = indice2;
-};
-
-TwoQubit::~TwoQubit(){ std::cout<<"Destructor TwoQubit"<<std::endl; };
-
-
-//
-//
-//RX GATE
-//
-//
-RxGate::RxGate( const int indice, const double angle ): OneQubit(indice) { 
-  (this->angle) = angle;
-};
-
-RxGate::~RxGate(){std::cout<<"Destructor RxGate"<<std::endl;};
-
-std::map<std::string, std::complex<double>> RxGate::aplicar_operador(std::map<std::string, std::complex<double>> dict_probs){
+std::map<std::string, std::complex<double>> OneQubit::aplicar_operador(std::map<std::string, std::complex<double>> dict_probs){
   std::map<std::string, std::complex<double>> new_probs;
   int index_accion = OneQubit::indice;
 
@@ -66,12 +47,70 @@ std::map<std::string, std::complex<double>> RxGate::aplicar_operador(std::map<st
   return new_probs;
 };
 
-std::tuple<std::complex<double>, std::complex<double>> RxGate::accion(const char flag, std::complex<double> prob1){
-  std::complex<double> i(0,1);
-  if( flag == '0' ){
-    return { prob1*cos( (this->angle)*0.5 ), -i*prob1*sin( (this->angle)*0.5 ) };
-  }
-  return { -i*prob1*sin( (this->angle)*0.5 ), prob1*cos( (this->angle)*0.5 ) };
+
+TwoQubit::TwoQubit( const int indice1, const int indice2 ){
+  (this->indice_1) = indice1;
+  (this->indice_2) = indice2;
+};
+
+TwoQubit::~TwoQubit(){ std::cout<<"Destructor TwoQubit"<<std::endl; };
+
+std::map<std::string, std::complex<double>> TwoQubit::aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ){
+  //iterar sobre estados
+  //tomar los 4 estados que representan 00 01 10 11 junto a sus probabilidades
+  std::map<std::string, std::complex<double>> new_probs;
+  int index_accion_1 = TwoQubit::indice_1;
+  int index_accion_2 = TwoQubit::indice_2;
+  
+  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
+    //4 estados basales
+    auto tuple_probs = accion( (it->first)[index_accion_1], (it->first)[index_accion_2], it->second);
+
+    //check
+    std::string estado = it->first;
+    estado[index_accion_1] = '0';
+    estado[index_accion_2] = '0';
+    std::complex<double> p = std::get<0>(tuple_probs);
+    auto it_estado2 = new_probs.find( estado );
+    if( it_estado2 != new_probs.end() ){
+      new_probs[ estado ] = (new_probs[ estado ]) + p;
+    }else{
+      new_probs[ estado ] = p;
+    };
+
+    estado[index_accion_1] = '0';
+    estado[index_accion_2] = '1';
+    p = std::get<1>(tuple_probs);
+    it_estado2 = new_probs.find( estado );
+    if( it_estado2 != new_probs.end() ){
+      new_probs[ estado ] = (new_probs[ estado ]) + p;
+    }else{
+      new_probs[ estado ] = p;
+    };
+
+    estado[index_accion_1] = '1';
+    estado[index_accion_2] = '0';
+    p = std::get<2>(tuple_probs);
+    it_estado2 = new_probs.find( estado );
+    if( it_estado2 != new_probs.end() ){
+      new_probs[ estado ] = (new_probs[ estado ]) + p;
+    }else{
+      new_probs[ estado ] = p;
+    };
+
+    estado[index_accion_1] = '1';
+    estado[index_accion_2] = '1';
+    p = std::get<3>(tuple_probs);
+    it_estado2 = new_probs.find( estado );
+    if( it_estado2 != new_probs.end() ){
+      new_probs[ estado ] = (new_probs[ estado]) + p;
+    }else{
+      new_probs[ estado ] = p;
+    };
+
+
+  };
+  return new_probs;
 };
 
 
@@ -94,37 +133,6 @@ std::tuple<std::complex<double>, std::complex<double>> RyGate::accion(const char
   return { -i*prob1*sin( (this->angle)*0.5 ), i*prob1*sin( (this->angle)*0.5 ) };
 };
 
-std::map<std::string, std::complex<double>> RyGate::aplicar_operador(std::map<std::string, std::complex<double>> dict_probs){
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion = OneQubit::indice;
-
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    std::string estado_2 = it->first;
-    estado_2[index_accion] = ( (it->first)[index_accion]=='0' ) ? '1' : '0';
-    std::complex<double> p1 = it->second;
-    std::complex<double> p2 = dict_probs[ estado_2 ];
-    auto tuple_probs = accion( (it->first)[index_accion], p1);
-    p1 = std::get<0>(tuple_probs);
-    p2 = std::get<1>(tuple_probs);
-      
-    auto it_estado1 = new_probs.find( it->first );
-    if( it_estado1 != new_probs.end() ){
-      new_probs[ it->first ] = (new_probs[ it->first ]) + p1;
-    }else{
-      new_probs[ it->first ] = p1;
-    };
-
-    auto it_estado2 = new_probs.find( estado_2 );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado_2 ] = (new_probs[ estado_2 ]) + p2;
-    }else{
-      new_probs[estado_2] = p2;
-    };
-
-  };
-  return new_probs;
-};
-
 //
 //
 //RZ GATE
@@ -143,37 +151,6 @@ std::tuple<std::complex<double>, std::complex<double>> RzGate::accion(const char
   return { 0.0, prob1*exp( i*(this->angle)*0.5 )};
 };
 
-std::map<std::string, std::complex<double>> RzGate::aplicar_operador(std::map<std::string, std::complex<double>> dict_probs){
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion = OneQubit::indice;
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    std::string estado_2 = it->first;
-    estado_2[index_accion] = ( (it->first)[index_accion]=='0' ) ? '1' : '0';
-    std::complex<double> p1 = it->second;
-    std::complex<double> p2 = dict_probs[ estado_2 ];
-    auto tuple_probs = accion( (it->first)[index_accion], p1);
-    p1 = std::get<0>(tuple_probs);
-    p2 = std::get<1>(tuple_probs);
-      
-    auto it_estado1 = new_probs.find( it->first );
-    if( it_estado1 != new_probs.end() ){
-      new_probs[ it->first ] = (new_probs[ it->first ]) + p1;
-    }else{
-      new_probs[ it->first ] = p1;
-    };
-
-    auto it_estado2 = new_probs.find( estado_2 );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado_2 ] = (new_probs[ estado_2 ]) + p2;
-    }else{
-      new_probs[estado_2] = p2;
-    };
-  };
-
-  return new_probs;
-};
-
-
 //
 //
 //HADAMARD GATE
@@ -191,37 +168,6 @@ std::tuple<std::complex<double>, std::complex<double>> HGate::accion(const char 
   return { (1.0/sqrt(2.0))*prob1, (-1.0/sqrt(2.0))*prob1 };
 };
 
-std::map<std::string, std::complex<double>> HGate::aplicar_operador(std::map<std::string, std::complex<double>> dict_probs){
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion = OneQubit::indice;
-
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    std::string estado_2 = it->first;
-    estado_2[index_accion] = ( (it->first)[index_accion]=='0' ) ? '1' : '0';
-    std::complex<double> p1 = it->second;
-    std::complex<double> p2 = dict_probs[ estado_2 ];
-    auto tuple_probs = accion( (it->first)[index_accion], p1);
-    p1 = std::get<0>(tuple_probs);
-    p2 = std::get<1>(tuple_probs);
-      
-    auto it_estado1 = new_probs.find( it->first );
-    if( it_estado1 != new_probs.end() ){
-      new_probs[ it->first ] = (new_probs[ it->first ]) + p1;
-    }else{
-      new_probs[ it->first ] = p1;
-    };
-
-    auto it_estado2 = new_probs.find( estado_2 );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado_2 ] = (new_probs[ estado_2 ]) + p2;
-    }else{
-      new_probs[estado_2] = p2;
-    };
-  };
-  return new_probs;
-};
-
-
 //
 //
 //X GATE
@@ -234,38 +180,6 @@ XGate::~XGate(){std::cout<<"Destructor Not gate"<<std::endl;};
 std::tuple<std::complex<double>, std::complex<double>> XGate::accion( const char flag, std::complex<double> prob1 ){
   return {0.0, prob1};
 };
-
-std::map<std::string, std::complex<double>> XGate::aplicar_operador(std::map<std::string, std::complex<double>> dict_probs){
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion = OneQubit::indice;
-
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    std::string estado_2 = it->first;
-    estado_2[index_accion] = ( (it->first)[index_accion]=='0' ) ? '1' : '0';
-    std::complex<double> p1 = it->second;
-    std::complex<double> p2 = dict_probs[ estado_2 ];
-
-    auto tuple_probs = accion( (it->first)[index_accion], p1);
-    p1 = std::get<0>(tuple_probs);
-    p2 = std::get<1>(tuple_probs);
-     
-    auto it_estado1 = new_probs.find( it->first );
-    if( it_estado1 != new_probs.end() ){
-      new_probs[ it->first ] = (new_probs[ it->first ]) + p1;
-    }else{
-      new_probs[ it->first ] = p1;
-    };
-
-    auto it_estado2 = new_probs.find( estado_2 );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado_2 ] = (new_probs[ estado_2 ]) + p2;
-    }else{
-      new_probs[estado_2] = p2;
-    };
-  };
-  return new_probs;
-};
-
 
 //
 //
@@ -282,39 +196,6 @@ std::tuple<std::complex<double>, std::complex<double>> ZGate::accion( const char
   };
   return {-prob1, 0.0};
 };
-
-std::map<std::string, std::complex<double>> ZGate::aplicar_operador(std::map<std::string, std::complex<double>> dict_probs){
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion = OneQubit::indice;
-
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    std::string estado_2 = it->first;
-    estado_2[index_accion] = ( (it->first)[index_accion]=='0' ) ? '1' : '0';
-    std::complex<double> p1 = it->second;
-    std::complex<double> p2 = dict_probs[ estado_2 ];
-
-    auto tuple_probs = accion( (it->first)[index_accion], p1);
-    p1 = std::get<0>(tuple_probs);
-    p2 = std::get<1>(tuple_probs);
-     
-    auto it_estado1 = new_probs.find( it->first );
-    if( it_estado1 != new_probs.end() ){
-      new_probs[ it->first ] = (new_probs[ it->first ]) + p1;
-    }else{
-      new_probs[ it->first ] = p1;
-    };
-
-    auto it_estado2 = new_probs.find( estado_2 );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado_2 ] = (new_probs[ estado_2 ]) + p2;
-    }else{
-      new_probs[estado_2] = p2;
-    };
-  };
-  return new_probs;
-};
-
-
 
 //
 //
@@ -333,38 +214,24 @@ std::tuple<std::complex<double>, std::complex<double>> YGate::accion( const char
   return {0.0, -i*prob1};
 };
 
-std::map<std::string, std::complex<double>> YGate::aplicar_operador(std::map<std::string, std::complex<double>> dict_probs){
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion = OneQubit::indice;
-
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    std::string estado_2 = it->first;
-    estado_2[index_accion] = ( (it->first)[index_accion]=='0' ) ? '1' : '0';
-    std::complex<double> p1 = it->second;
-    std::complex<double> p2 = dict_probs[ estado_2 ];
-
-    auto tuple_probs = accion( (it->first)[index_accion], p1);
-    p1 = std::get<0>(tuple_probs);
-    p2 = std::get<1>(tuple_probs);
-     
-    auto it_estado1 = new_probs.find( it->first );
-    if( it_estado1 != new_probs.end() ){
-      new_probs[ it->first ] = (new_probs[ it->first ]) + p1;
-    }else{
-      new_probs[ it->first ] = p1;
-    };
-
-    auto it_estado2 = new_probs.find( estado_2 );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado_2 ] = (new_probs[ estado_2 ]) + p2;
-    }else{
-      new_probs[estado_2] = p2;
-    };
-  };
-  return new_probs;
+//
+//
+//RX GATE
+//
+//
+RxGate::RxGate( const int indice, const double angle ): OneQubit(indice) { 
+  (this->angle) = angle;
 };
 
+RxGate::~RxGate(){std::cout<<"Destructor RxGate"<<std::endl;};
 
+std::tuple<std::complex<double>, std::complex<double>> RxGate::accion(const char flag, std::complex<double> prob1){
+  std::complex<double> i(0,1);
+  if( flag == '0' ){
+    return { prob1*cos( (this->angle)*0.5 ), -i*prob1*sin( (this->angle)*0.5 ) };
+  }
+  return { -i*prob1*sin( (this->angle)*0.5 ), prob1*cos( (this->angle)*0.5 ) };
+};
 
 //
 //
@@ -387,65 +254,6 @@ std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, st
   return {0.0, 0.0, prob, 0.0};
 };
 
-std::map<std::string, std::complex<double>> CnotGate::aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ){
-  //iterar sobre estados
-  //tomar los 4 estados que representan 00 01 10 11 junto a sus probabilidades
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion_1 = TwoQubit::indice_1;
-  int index_accion_2 = TwoQubit::indice_2;
-  
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    //4 estados basales
-    auto tuple_probs = accion( (it->first)[index_accion_1], (it->first)[index_accion_2], it->second);
-
-    //check
-    std::string estado = it->first;
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '0';
-    std::complex<double> p = std::get<0>(tuple_probs);
-    auto it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '1';
-    p = std::get<1>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '0';
-    p = std::get<2>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '1';
-    p = std::get<3>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-
-  };
-  return new_probs;
-};
-
-
 //
 //
 //CZ GATE
@@ -466,66 +274,6 @@ std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, st
   }; 
   return {0.0, 0.0, 0.0, -prob};
 };
-
-std::map<std::string, std::complex<double>> CZGate::aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ){
-  //iterar sobre estados
-  //tomar los 4 estados que representan 00 01 10 11 junto a sus probabilidades
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion_1 = TwoQubit::indice_1;
-  int index_accion_2 = TwoQubit::indice_2;
-  
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    //4 estados basales
-    auto tuple_probs = accion( (it->first)[index_accion_1], (it->first)[index_accion_2], it->second);
-
-    //check
-    std::string estado = it->first;
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '0';
-    std::complex<double> p = std::get<0>(tuple_probs);
-    auto it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '1';
-    p = std::get<1>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '0';
-    p = std::get<2>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '1';
-    p = std::get<3>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-
-  };
-  return new_probs;
-};
-
-
 
 //
 //
@@ -548,66 +296,6 @@ std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, st
   }; 
   return {0.0, 0.0, -i*prob, 0.0};
 };
-
-std::map<std::string, std::complex<double>> CYGate::aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ){
-  //iterar sobre estados
-  //tomar los 4 estados que representan 00 01 10 11 junto a sus probabilidades
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion_1 = TwoQubit::indice_1;
-  int index_accion_2 = TwoQubit::indice_2;
-  
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    //4 estados basales
-    auto tuple_probs = accion( (it->first)[index_accion_1], (it->first)[index_accion_2], it->second);
-
-    //check
-    std::string estado = it->first;
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '0';
-    std::complex<double> p = std::get<0>(tuple_probs);
-    auto it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '1';
-    p = std::get<1>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '0';
-    p = std::get<2>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '1';
-    p = std::get<3>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-
-  };
-  return new_probs;
-};
-
-
 //
 //
 //CH GATE
@@ -628,66 +316,6 @@ std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, st
   }; 
   return {0.0, 0.0, (-1.0/sqrt(2.0))*prob, (1.0/sqrt(2.0))*prob};
 };
-
-
-std::map<std::string, std::complex<double>> CHGate::aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ){
-  //iterar sobre estados
-  //tomar los 4 estados que representan 00 01 10 11 junto a sus probabilidades
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion_1 = TwoQubit::indice_1;
-  int index_accion_2 = TwoQubit::indice_2;
-  
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    //4 estados basales
-    auto tuple_probs = accion( (it->first)[index_accion_1], (it->first)[index_accion_2], it->second);
-
-    //check
-    std::string estado = it->first;
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '0';
-    std::complex<double> p = std::get<0>(tuple_probs);
-    auto it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '1';
-    p = std::get<1>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '0';
-    p = std::get<2>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '1';
-    p = std::get<3>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-
-  };
-  return new_probs;
-};
-
 
 //
 //
@@ -717,65 +345,6 @@ std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, st
   return {0.0, 0.0, val1, val2};
 };
 
-std::map<std::string, std::complex<double>> CRXGate::aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ){
-  //iterar sobre estados
-  //tomar los 4 estados que representan 00 01 10 11 junto a sus probabilidades
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion_1 = TwoQubit::indice_1;
-  int index_accion_2 = TwoQubit::indice_2;
-  
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    //4 estados basales
-    auto tuple_probs = accion( (it->first)[index_accion_1], (it->first)[index_accion_2], it->second);
-
-    //check
-    std::string estado = it->first;
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '0';
-    std::complex<double> p = std::get<0>(tuple_probs);
-    auto it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '1';
-    p = std::get<1>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '0';
-    p = std::get<2>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '1';
-    p = std::get<3>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-
-  };
-  return new_probs;
-};
-
-
 //
 //
 //CRY GATE
@@ -804,68 +373,6 @@ std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, st
   return {0.0, 0.0, val1, val2};
 };
 
-std::map<std::string, std::complex<double>> CRYGate::aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ){
-  //iterar sobre estados
-  //tomar los 4 estados que representan 00 01 10 11 junto a sus probabilidades
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion_1 = TwoQubit::indice_1;
-  int index_accion_2 = TwoQubit::indice_2;
-  
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    //4 estados basales
-    auto tuple_probs = accion( (it->first)[index_accion_1], (it->first)[index_accion_2], it->second);
-
-    //check
-    std::string estado = it->first;
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '0';
-    std::complex<double> p = std::get<0>(tuple_probs);
-    auto it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '1';
-    p = std::get<1>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '0';
-    p = std::get<2>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '1';
-    p = std::get<3>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-
-  };
-  return new_probs;
-};
-
-
-
-
-
 //
 //
 //CRZ GATE
@@ -892,62 +399,4 @@ std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, st
   std::complex<double> val1 = 0.0;
   std::complex<double> val2 = prob*exp( i*(this->angle)*0.5 );
   return {0.0, 0.0, val1, val2};
-};
-
-std::map<std::string, std::complex<double>> CRZGate::aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ){
-  //iterar sobre estados
-  //tomar los 4 estados que representan 00 01 10 11 junto a sus probabilidades
-  std::map<std::string, std::complex<double>> new_probs;
-  int index_accion_1 = TwoQubit::indice_1;
-  int index_accion_2 = TwoQubit::indice_2;
-  
-  for( auto it=dict_probs.begin(); it!=dict_probs.end(); it++ ){
-    //4 estados basales
-    auto tuple_probs = accion( (it->first)[index_accion_1], (it->first)[index_accion_2], it->second);
-
-    //check
-    std::string estado = it->first;
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '0';
-    std::complex<double> p = std::get<0>(tuple_probs);
-    auto it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '0';
-    estado[index_accion_2] = '1';
-    p = std::get<1>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '0';
-    p = std::get<2>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado ]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-    estado[index_accion_1] = '1';
-    estado[index_accion_2] = '1';
-    p = std::get<3>(tuple_probs);
-    it_estado2 = new_probs.find( estado );
-    if( it_estado2 != new_probs.end() ){
-      new_probs[ estado ] = (new_probs[ estado]) + p;
-    }else{
-      new_probs[ estado ] = p;
-    };
-
-
-  };
-  return new_probs;
 };

--- a/qc-circuit/operators.h
+++ b/qc-circuit/operators.h
@@ -24,7 +24,7 @@ class OneQubit: public Operator{
     OneQubit( const int indice );
     virtual ~OneQubit();
     virtual std::tuple<std::complex<double>, std::complex<double>> accion( const char flag, std::complex<double> prob1)=0;
-    virtual std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs )=0;
+    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 
@@ -37,7 +37,7 @@ class TwoQubit: public Operator{
     virtual ~TwoQubit();
     virtual std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, std::complex<double> > 
       accion(const char flag1, const char flag2, std::complex<double> prob)=0;
-    virtual std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs )=0; 
+    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final; 
 };
 
 
@@ -50,9 +50,6 @@ class RxGate: public OneQubit{
     RxGate( const int indice, const double angle );
     ~RxGate();
     std::tuple<std::complex<double>, std::complex<double>> accion( const char flag, std::complex<double> prob1) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
-
-  
 };
 
 class RyGate: public OneQubit{
@@ -62,8 +59,6 @@ class RyGate: public OneQubit{
     RyGate( const int indice, const double angle );
     ~RyGate();
     std::tuple<std::complex<double>, std::complex<double>> accion(const char flag, std::complex<double> prob1) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
-
 };
 
 class RzGate: public OneQubit{
@@ -73,7 +68,6 @@ class RzGate: public OneQubit{
     RzGate( const int indice, const double angle );
     ~RzGate();
     std::tuple<std::complex<double>, std::complex<double>> accion(const char flag, std::complex<double> prob1) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 class HGate: public OneQubit{
@@ -81,7 +75,6 @@ class HGate: public OneQubit{
     HGate( const int indice );
     ~HGate();
     std::tuple<std::complex<double>, std::complex<double>> accion(const char flag, std::complex<double> prob1) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 class XGate: public OneQubit{
@@ -89,7 +82,6 @@ class XGate: public OneQubit{
     XGate( const int indice );
     ~XGate();
     std::tuple<std::complex<double>, std::complex<double>> accion(const char flag, std::complex<double> prob1) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 class ZGate: public OneQubit{
@@ -97,7 +89,6 @@ class ZGate: public OneQubit{
     ZGate( const int indice );
     ~ZGate();
     std::tuple<std::complex<double>, std::complex<double>> accion(const char flag, std::complex<double> prob1) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 class YGate: public OneQubit{
@@ -105,7 +96,6 @@ class YGate: public OneQubit{
     YGate( const int indice );
     ~YGate();
     std::tuple<std::complex<double>, std::complex<double>> accion(const char flag, std::complex<double> prob1) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 
@@ -116,7 +106,6 @@ class CnotGate: public TwoQubit{
     ~CnotGate();
     std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, std::complex<double> >
       accion(const char flag1, const char flag2, std::complex<double> prob) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 class CZGate: public TwoQubit{
@@ -125,7 +114,6 @@ class CZGate: public TwoQubit{
     ~CZGate();
     std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, std::complex<double> >
       accion(const char flag1, const char flag2, std::complex<double> prob) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 class CYGate: public TwoQubit{
@@ -134,7 +122,6 @@ class CYGate: public TwoQubit{
     ~CYGate();
     std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, std::complex<double> >
       accion(const char flag1, const char flag2, std::complex<double> prob) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 class CHGate: public TwoQubit{
@@ -143,7 +130,6 @@ class CHGate: public TwoQubit{
     ~CHGate();
     std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, std::complex<double> >
       accion(const char flag1, const char flag2, std::complex<double> prob) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 class CRXGate: public TwoQubit{
@@ -154,7 +140,6 @@ private:
     ~CRXGate();
     std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, std::complex<double> >
       accion(const char flag1, const char flag2, std::complex<double> prob) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 
@@ -166,7 +151,6 @@ private:
     ~CRYGate();
     std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, std::complex<double> >
       accion(const char flag1, const char flag2, std::complex<double> prob) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 
@@ -178,7 +162,6 @@ private:
     ~CRZGate();
     std::tuple< std::complex<double>, std::complex<double>, std::complex<double>, std::complex<double> >
       accion(const char flag1, const char flag2, std::complex<double> prob) final;
-    std::map<std::string, std::complex<double>> aplicar_operador( std::map<std::string, std::complex<double>> dict_probs ) final;
 };
 
 


### PR DESCRIPTION
Refactor the operators code.
The aplicar_operador definitions move to the parent class (OneQubit and TwoQubit).